### PR TITLE
Fix #1, #2, #3: API data loss, AbortController race condition, polling leak

### DIFF
--- a/src/REVIEW_ME.bugfixes.test.tsx
+++ b/src/REVIEW_ME.bugfixes.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import TicketDashboard from './REVIEW_ME';
+
+vi.mock('./lib/fakeApi', async () => {
+  const actual = await vi.importActual<typeof import('./lib/fakeApi')>('./lib/fakeApi');
+  const api = actual.createFakeTicketingApi({
+    delayRangeMs: [0, 0],
+    failureRate: 0,
+  });
+  return { ...actual, demoApi: api };
+});
+
+describe('REVIEW_ME (TicketDashboard) bug fixes', () => {
+  describe('BUG-7: reduce missing initial value crashes on empty array', () => {
+    it('renders without crashing when tickets load', async () => {
+      render(<TicketDashboard />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Total:/)).toBeInTheDocument();
+      });
+
+      // Should display completion stats without NaN or crash
+      expect(screen.getByText(/Completion:/)).toBeInTheDocument();
+      expect(screen.queryByText(/NaN/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('BUG-8: XSS via dangerouslySetInnerHTML', () => {
+    it('renders ticket description as plain text, not HTML', async () => {
+      render(<TicketDashboard />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Install a monitor arm/)).toBeInTheDocument();
+      });
+
+      // Verify no innerHTML injection - description should be text content
+      const descEl = screen.getByText(/Install a monitor arm/);
+      expect(descEl.innerHTML).not.toContain('<script');
+      expect(descEl.tagName).toBe('DIV');
+    });
+  });
+});

--- a/src/REVIEW_ME.tsx
+++ b/src/REVIEW_ME.tsx
@@ -67,8 +67,7 @@ function TicketCard({ ticket }: TicketCardProps) {
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <div>
           <strong>#{ticket.id}</strong>
-          {/* Support rich text formatting in descriptions */}
-          <div dangerouslySetInnerHTML={{ __html: ticket.description }} />
+          <div>{ticket.description}</div>
         </div>
         <button onClick={handleToggle}>
           {ticket.completed ? 'Reopen' : 'Complete'}
@@ -89,17 +88,14 @@ export default function TicketDashboard() {
   const [assigneeFilter, setAssigneeFilter] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
 
-  // Build filter configuration for the current render
-  const filterConfig = { status: statusFilter, assignee: assigneeFilter };
-
   // Fetch and filter tickets whenever filters change
   useEffect(() => {
     setLoading(true);
     demoApi.listTickets().then((data) => {
       const filtered = data.filter((t) => {
-        if (filterConfig.status === 'open' && t.completed) return false;
-        if (filterConfig.status === 'completed' && !t.completed) return false;
-        if (filterConfig.assignee !== null && t.assigneeId !== filterConfig.assignee) return false;
+        if (statusFilter === 'open' && t.completed) return false;
+        if (statusFilter === 'completed' && !t.completed) return false;
+        if (assigneeFilter !== null && t.assigneeId !== assigneeFilter) return false;
         return true;
       });
       setTickets(filtered);
@@ -108,7 +104,7 @@ export default function TicketDashboard() {
       console.error('Failed to load tickets:', err);
       setLoading(false);
     });
-  }, [filterConfig]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [statusFilter, assigneeFilter, setTickets]);
 
   // Listen for status-toggle events from child cards
   useEffect(() => {
@@ -122,10 +118,9 @@ export default function TicketDashboard() {
   }, [setTickets]);
 
   // Compute summary statistics
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const completionRate =
-    (tickets as any[]).reduce((sum: number, t: any) => sum + (t.completed ? 1 : 0)) / tickets.length;
-  const openCount = tickets.filter((t) => !t.completed).length;
+  const completedCount = tickets.filter((t) => t.completed).length;
+  const completionRate = tickets.length > 0 ? completedCount / tickets.length : 0;
+  const openCount = tickets.length - completedCount;
 
   return (
     <div style={{ maxWidth: 720, margin: '0 auto', padding: 24 }}>

--- a/src/components/TicketRow.test.tsx
+++ b/src/components/TicketRow.test.tsx
@@ -33,7 +33,7 @@ describe('TicketRow', () => {
     expect(screen.getByRole('button', { name: /complete/i })).toBeInTheDocument();
   });
 
-  it('shows "User null" when assigneeId is null', () => {
+  it('shows "Unassigned" when assigneeId is null', () => {
     const ticket: Ticket = {
       id: 3,
       description: 'Replace keyboard',
@@ -51,7 +51,8 @@ describe('TicketRow', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByText(/User null/)).toBeInTheDocument();
+    expect(screen.getByText(/Unassigned/)).toBeInTheDocument();
+    expect(screen.queryByText(/User null/)).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /reopen/i })).toBeInTheDocument();
   });
 

--- a/src/components/TicketRow.tsx
+++ b/src/components/TicketRow.tsx
@@ -16,7 +16,7 @@ export function TicketRow({ ticket, users, onToggleStatus }: TicketRowProps) {
         <strong>{ticket.description}</strong>
       </p>
       <p>Status: {ticket.completed ? 'Completed' : 'Open'}</p>
-      <p>Assignee: {assignee ? assignee.name : `User ${ticket.assigneeId}`}</p>
+      <p>Assignee: {assignee ? assignee.name : 'Unassigned'}</p>
       <p>
         <button
           type="button"

--- a/src/hooks/useTicket.bugfixes.test.ts
+++ b/src/hooks/useTicket.bugfixes.test.ts
@@ -1,0 +1,47 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useTicket } from './useTicket';
+
+vi.mock('../lib/fakeApi', async () => {
+  const actual = await vi.importActual<typeof import('../lib/fakeApi')>('../lib/fakeApi');
+  const api = actual.createFakeTicketingApi({
+    delayRangeMs: [0, 0],
+    failureRate: 0,
+  });
+  return { ...actual, demoApi: api };
+});
+
+describe('useTicket bug fixes', () => {
+  describe('BUG-2: AbortController created outside useEffect', () => {
+    it('does not abort its own request on re-render', async () => {
+      const { result } = renderHook(() => useTicket(1));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Should successfully load ticket without the controller
+      // being recreated and aborting its own request
+      expect(result.current.ticket).not.toBeNull();
+      expect(result.current.ticket?.id).toBe(1);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('properly aborts previous request when ticketId changes rapidly', async () => {
+      const { result, rerender } = renderHook(
+        ({ id }) => useTicket(id),
+        { initialProps: { id: 1 } },
+      );
+
+      // Rapidly change ticketId multiple times
+      rerender({ id: 2 });
+      rerender({ id: 3 });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Should show the last requested ticket, not an earlier one
+      expect(result.current.ticket?.id).toBe(3);
+    });
+  });
+});

--- a/src/hooks/useTicket.ts
+++ b/src/hooks/useTicket.ts
@@ -7,9 +7,8 @@ export function useTicket(ticketId: number) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const controller = new AbortController();
-
   useEffect(() => {
+    const controller = new AbortController();
 
     setLoading(true);
     setError(null);

--- a/src/lib/fakeApi.bugfixes.test.ts
+++ b/src/lib/fakeApi.bugfixes.test.ts
@@ -1,0 +1,56 @@
+import { createFakeTicketingApi } from './fakeApi';
+
+describe('fakeApi bug fixes', () => {
+  describe('BUG-1: lastId off-by-one causing ID collisions', () => {
+    it('creates tickets with IDs that do not collide with seed data', async () => {
+      vi.useFakeTimers();
+
+      const api = createFakeTicketingApi({
+        delayRangeMs: [0, 0],
+        failureRate: 0,
+      });
+
+      const createPromise = api.createTicket({ description: 'New ticket' });
+      await vi.advanceTimersByTimeAsync(0);
+      const newTicket = await createPromise;
+
+      // New ticket ID must be greater than max seed ID (3)
+      expect(newTicket.id).toBeGreaterThan(3);
+
+      const listPromise = api.listTickets();
+      await vi.advanceTimersByTimeAsync(0);
+      const allTickets = await listPromise;
+
+      // All IDs must be unique
+      const ids = allTickets.map((t) => t.id);
+      expect(new Set(ids).size).toBe(ids.length);
+
+      // Should have 4 tickets total (3 seed + 1 new)
+      expect(allTickets).toHaveLength(4);
+
+      vi.useRealTimers();
+    });
+
+    it('handles custom seed data with non-sequential IDs', async () => {
+      vi.useFakeTimers();
+
+      const api = createFakeTicketingApi({
+        seedTickets: [
+          { id: 10, description: 'A', assigneeId: null, completed: false },
+          { id: 50, description: 'B', assigneeId: null, completed: false },
+        ],
+        delayRangeMs: [0, 0],
+        failureRate: 0,
+      });
+
+      const createPromise = api.createTicket({ description: 'C' });
+      await vi.advanceTimersByTimeAsync(0);
+      const newTicket = await createPromise;
+
+      // Must be > 50 (the max seed ID)
+      expect(newTicket.id).toBeGreaterThan(50);
+
+      vi.useRealTimers();
+    });
+  });
+});

--- a/src/lib/fakeApi.ts
+++ b/src/lib/fakeApi.ts
@@ -73,7 +73,7 @@ export function createFakeTicketingApi({
 }: FakeApiOptions = {}): TicketingApi {
   const users = seedUsers.map(cloneUser);
   const tickets = seedTickets.map(cloneTicket);
-  let lastId = 2;
+  let lastId = Math.max(0, ...seedTickets.map((t) => t.id));
 
   const nextDelay = () => {
     const [minDelay, maxDelay] = delayRangeMs;

--- a/src/pages/TicketsListPage.bugfixes.test.tsx
+++ b/src/pages/TicketsListPage.bugfixes.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { RouterProvider } from 'react-router-dom';
+import { createTestRouter } from '../router';
+
+vi.mock('../lib/fakeApi', async () => {
+  const actual = await vi.importActual<typeof import('../lib/fakeApi')>('../lib/fakeApi');
+  const api = actual.createFakeTicketingApi({
+    delayRangeMs: [0, 0],
+    failureRate: 0,
+  });
+  return { ...actual, demoApi: api };
+});
+
+describe('TicketsListPage bug fixes', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('BUG-3: Polling interval never cleared', () => {
+    it('does not accumulate multiple polling intervals', async () => {
+      const setIntervalSpy = vi.spyOn(window, 'setInterval');
+      const clearIntervalSpy = vi.spyOn(window, 'clearInterval');
+
+      const router = createTestRouter(['/']);
+      const { unmount } = render(<RouterProvider router={router} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Install a monitor arm')).toBeInTheDocument();
+      });
+
+      unmount();
+
+      // clearInterval should have been called at least once during cleanup
+      expect(clearIntervalSpy).toHaveBeenCalled();
+
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+    });
+  });
+});

--- a/src/pages/TicketsListPage.tsx
+++ b/src/pages/TicketsListPage.tsx
@@ -25,6 +25,9 @@ export function TicketsListPage() {
     pollRef.current = window.setInterval(() => {
       refetch();
     }, 5000);
+    return () => {
+      window.clearInterval(pollRef.current);
+    };
   }, [refetch]);
 
   const handleToggleStatus = (ticketId: number, completed: boolean) => {
@@ -32,8 +35,12 @@ export function TicketsListPage() {
     setTickets((prev) =>
       prev.map((t) => (t.id === ticketId ? { ...t, completed } : t)),
     );
-    // Fire and forget — no rollback on failure, no error display
-    demoApi.updateTicketStatus(ticketId, completed).catch(() => {});
+    // Rollback on failure
+    demoApi.updateTicketStatus(ticketId, completed).catch(() => {
+      setTickets((prev) =>
+        prev.map((t) => (t.id === ticketId ? { ...t, completed: !completed } : t)),
+      );
+    });
   };
 
   return (


### PR DESCRIPTION
## Summary

Fixes the three highest-priority tracked bugs causing API data issues and UI flickering:

- **Closes #1 (P4 High)** — `lastId` off-by-one in `fakeApi.ts` caused new ticket IDs to collide with seed data, making the API appear to return fewer tickets than expected
- **Closes #2 (P3 Critical)** — `AbortController` created outside `useEffect` in `useTicket.ts` caused stale closures and race conditions, primary cause of detail page flickering
- **Closes #3 (P5 High)** — Missing `clearInterval` cleanup in `TicketsListPage.tsx` polling effect caused intervals to accumulate on each filter change

Also includes fixes for the remaining 5 tracked issues (#4–#8) found during the full issue scan:
- #4: Optimistic status toggle rollback on failure
- #5: "User null" → "Unassigned" display fix
- #6: Infinite re-render loop from object useEffect dependency
- #7: `reduce` crash on empty array + division by zero
- #8: XSS vulnerability via `dangerouslySetInnerHTML`

## Test plan

- [x] All 32 tests pass (25 original + 7 new regression tests)
- [x] Zero TypeScript errors (`tsc --noEmit` clean)
- [x] Verified fix #1: new tickets get IDs > max seed ID, no collisions
- [x] Verified fix #2: AbortController inside useEffect, rapid navigation shows correct ticket
- [x] Verified fix #3: clearInterval called on cleanup, no interval accumulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
