### PR TITLE
fix: add horizontal scrollbar to swim lanes container

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -58,6 +58,7 @@ form {
   gap: 1rem;
   overflow-x: auto;
   padding-bottom: 1rem;
+  max-width: calc(100vw - 2rem);
 }
 
 .swim-lane {


### PR DESCRIPTION
- Swim lanes in the Groups page were cut off horizontally with no way to scroll between them                                                                                 
  - Added max-width: calc(100vw - 2rem) to .swim-lanes-container so overflow-x: auto has a definite boundary and renders a scrollbar                                           
                                                                                                                                                                               
  Test plan                                                                                                                                                                    
                                                                                                                                                                               
  - Open the Groups page with enough groups to exceed the viewport width                                                                                                       
  - Verify a horizontal scrollbar appears and all swim lanes are accessible                                                                                                    
                                                                             